### PR TITLE
Allow custom secrets per hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If you are editing these permanent urls after they have already been committed t
  - `redis-cli flushall`
  - **_IMPORTANT:_** Running the above command clears the redis database entirely. This will result in all meetings, processing or not, to be cleared from the database, and may result in broken meetings currently processing.
 
+### Per-hook secret key
+
+When creating a hook with the `/bigbluebutton/api/hooks/create` endpoint you can pass an optional `secret` query parameter. If provided, webhook callbacks for that hook will be signed using this secret instead of the value configured in `bbb.sharedSecret`.
+
+### Override meeting identifier
+
+Hooks created via `/bigbluebutton/api/hooks/create` may also include an `originalMeetingID` query parameter. When present, the `external-meeting-id` field of delivered events will be replaced with this value, allowing you to mask the true external identifier.
+
 ## Manually installing the application on a BBB server
 
 Follow the commands below starting within the `bigbluebutton/bbb-webhooks` directory.

--- a/src/db/redis/hooks.js
+++ b/src/db/redis/hooks.js
@@ -34,6 +34,8 @@ class HookCompartment extends StorageCompartmentKV {
       permanent: payload.permanent === 'true',
       // Should be a boolean
       getRaw: payload.getRaw === 'true',
+      secret: payload.secret,
+      originalMeetingID: payload.originalMeetingID,
     };
 
     return {
@@ -50,6 +52,8 @@ class HookCompartment extends StorageCompartmentKV {
     callbackURL,
     meetingID = null,
     eventID = null,
+    secret = null,
+    originalMeetingID = null,
     permanent = false,
     getRaw = false,
   }) {
@@ -59,6 +63,8 @@ class HookCompartment extends StorageCompartmentKV {
       callbackURL,
       externalMeetingID: meetingID,
       eventID,
+      secret,
+      originalMeetingID,
       permanent,
       getRaw,
     }
@@ -90,6 +96,8 @@ class HookCompartment extends StorageCompartmentKV {
     callbackURL,
     meetingID,
     eventID,
+    secret,
+    originalMeetingID,
     permanent,
     getRaw,
   }) {
@@ -97,6 +105,8 @@ class HookCompartment extends StorageCompartmentKV {
       callbackURL,
       meetingID,
       eventID: eventID?.toLowerCase().split(','),
+      secret,
+      originalMeetingID,
       permanent,
       getRaw,
     });

--- a/src/out/webhooks/api/api.js
+++ b/src/out/webhooks/api/api.js
@@ -70,6 +70,8 @@ export default class API {
     const callbackURL = urlObj.query["callbackURL"];
     const meetingID = urlObj.query["meetingID"];
     const eventID = urlObj.query["eventID"];
+    const secret = urlObj.query["secret"];
+    const originalMeetingID = urlObj.query["originalMeetingID"];
     let getRaw = urlObj.query["getRaw"];
     let returncode = responses.RETURN_CODES.SUCCESS;
     let messageKey;
@@ -90,6 +92,8 @@ export default class API {
           callbackURL,
           meetingID,
           eventID,
+          secret,
+          originalMeetingID,
           permanent: this._isHookPermanent(callbackURL),
           getRaw,
         });
@@ -188,11 +192,13 @@ export default class API {
           callbackURL,
           permanent,
           getRaw,
+          originalMeetingID,
         } = hook.payload;
         msg += "<hook>";
         msg +=   `<hookID>${hook.id}</hookID>`;
         msg +=   `<callbackURL><![CDATA[${callbackURL}]]></callbackURL>`;
         if (!API.storage.get().isGlobal(hook)) { msg +=   `<meetingID><![CDATA[${externalMeetingID}]]></meetingID>`; }
+        if (originalMeetingID != null) { msg +=   `<originalMeetingID><![CDATA[${originalMeetingID}]]></originalMeetingID>`; }
         if (eventID != null) { msg +=   `<eventID>${eventID}</eventID>`; }
         msg +=   `<permanentHook>${permanent}</permanentHook>`;
         msg +=   `<rawData>${getRaw}</rawData>`;

--- a/src/out/webhooks/web-hooks.js
+++ b/src/out/webhooks/web-hooks.js
@@ -1,6 +1,7 @@
 import CallbackEmitter from './callback-emitter.js';
 import HookCompartment from '../../db/redis/hooks.js';
 import { METRIC_NAMES } from './metrics.js';
+import config from 'config';
 
 /**
  * WebHooks.
@@ -170,13 +171,22 @@ class WebHooks {
         return;
       }
 
+      let outEvent = event;
+      if (hook.payload.originalMeetingID) {
+        outEvent = config.util.cloneDeep(event);
+        const orig = hook.payload.originalMeetingID;
+        if (outEvent?.data?.attributes?.meeting?.['external-meeting-id'] != null) {
+          outEvent.data.attributes.meeting['external-meeting-id'] = orig;
+        }
+      }
+
       const emitter = new CallbackEmitter(
         hook.payload.callbackURL,
-        event,
+        outEvent,
         hook.payload.permanent,
         this.config.server.domain, {
           permanentIntervalReset: this.config.permanentIntervalReset,
-          secret: this.config.server.secret,
+          secret: hook.payload.secret || this.config.server.secret,
           auth2_0: this.config.server.auth2_0,
           requestTimeout: this.config.requestTimeout,
           retryIntervals: this.config.retryIntervals,

--- a/test/webhooks/index.js
+++ b/test/webhooks/index.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 import config from 'config';
 import Utils from '../../src/out/webhooks/utils.js';
 import Hook from '../../src/db/redis/hooks.js';
+import IDMapping from '../../src/db/redis/id-mapping.js';
 import Helpers from './helpers.js'
 import HooksPostCatcher from './hooks-post-catcher.js';
 
@@ -144,6 +145,98 @@ export default function suite({
           }
         })
     })
+  });
+
+  describe('GET /hooks/create custom secret', () => {
+    const customSecret = 'mysecret';
+    after((done) => {
+      const hooks = Hook.get().getAllGlobalHooks();
+      Hook.get().removeSubscription(hooks[hooks.length-1].id)
+        .then(() => { done(); })
+        .catch(done);
+    });
+
+    it('should store provided secret with the hook', (done) => {
+      let params = Helpers.createUrl + '&secret=' + customSecret;
+      let getUrl = Utils.checksumAPI(
+        Helpers.url + params,
+        sharedSecret,
+        CHECKSUM_ALGORITHM,
+      );
+      const finalUrl = params + '&checksum=' + getUrl;
+
+      request(Helpers.url)
+        .get(finalUrl)
+        .expect('Content-Type', /text\/xml/)
+        .expect(200, () => {
+          const hooks = Hook.get().getAllGlobalHooks();
+          if (hooks && hooks.some((hook) => hook.payload.secret === customSecret)) {
+            done();
+          } else {
+            done(new Error('hook secret not stored'));
+          }
+        });
+    });
+  });
+
+  describe('GET /hooks/create originalMeetingID', () => {
+    const customId = 'orig-123';
+    let catcher;
+
+    before((done) => {
+      catcher = new HooksPostCatcher(Helpers.callback);
+      catcher.start()
+        .then(() => IDMapping.get().addOrUpdateMapping(
+          Helpers.rawMessage.envelope.routing.meetingId,
+          'original-ext'))
+        .then(() => done())
+        .catch(done);
+    });
+
+    after((done) => {
+      catcher.stop();
+      const hooks = Hook.get().getAllGlobalHooks();
+      Hook.get().removeSubscription(hooks[hooks.length-1].id)
+        .then(() => { done(); })
+        .catch(done);
+    });
+
+    it('should use provided originalMeetingID in callbacks', (done) => {
+      let params = Helpers.createUrl + '&originalMeetingID=' + customId;
+      let getUrl = Utils.checksumAPI(
+        Helpers.url + params,
+        sharedSecret,
+        CHECKSUM_ALGORITHM,
+      );
+      const finalUrl = params + '&checksum=' + getUrl;
+
+      request(Helpers.url)
+        .get(finalUrl)
+        .expect('Content-Type', /text\/xml/)
+        .expect(200, () => {
+          const hooks = Hook.get().getAllGlobalHooks();
+          const hook = hooks[hooks.length-1];
+          if (!hook || hook.payload.originalMeetingID !== customId) {
+            done(new Error('hook originalMeetingID not stored'));
+            return;
+          }
+
+          catcher.once('callback', (body) => {
+            try {
+              const parsed = JSON.parse(body.event);
+              if (parsed[0].data.attributes.meeting['external-meeting-id'] === customId) {
+                done();
+              } else {
+                done(new Error('meeting id not replaced'));
+              }
+            } catch (error) {
+              done(error);
+            }
+          });
+
+          redisClient.publish(testChannel, JSON.stringify(Helpers.rawMessage));
+        });
+    });
   });
 
   describe('GET /hooks/create without checksum', () => {


### PR DESCRIPTION
## Summary
- store a secret for each webhook if provided on the API request
- use the per-hook secret when generating callback checksums
- document the new `secret` parameter
- allow setting an `originalMeetingID` for each hook
- replace meeting IDs in callbacks with `originalMeetingID`
- test meeting ID override behavior
- replace external meeting-id with override value
- list `originalMeetingID` in hook listing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68499e6fac8c832a8131109bf33cb284